### PR TITLE
Add Python Dependabot Configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,19 @@ updates:
         update-types:
           - "patch"
           - "minor"
+
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "cron"
+      cronjob: "30 7 * * *"
+      timezone: "Europe/London"
+    target-branch: "main"
+    groups:
+      uv:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+          - "minor"


### PR DESCRIPTION
# Pull Request

## Description

This pull request adds a new configuration for Dependabot in the `.github/dependabot.yml` file to manage updates for the `uv` package ecosystem. The changes introduce a scheduled cron job and grouping for version updates.

### Dependabot configuration enhancements:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R22-R37): Added a new `uv` package ecosystem configuration with a cron schedule set to "30 7 * * *" in the "Europe/London" timezone. This configuration targets the `main` branch and includes grouping for version updates with patterns and update types specified as "patch" and "minor."