### PR TITLE
Update minimum UV versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "gitdash"
 dynamic = ["version"]
-requires-python = ">=3.13"
+requires-python = "~=3.13.0"
 dependencies = [
   "ruff==0.12.3",
   "textual-dev==1.7.0",
@@ -9,7 +9,7 @@ dependencies = [
 ]
 
 [tool.uv]
-required-version = "0.7.20"
+required-version = "~=0.8.0"
 package = false
 
 [tool.ruff]

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 2
-requires-python = ">=3.13"
+requires-python = "==3.13.*"
 
 [[package]]
 name = "aiohappyeyeballs"


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates version constraints for Python and the `uv` tool in the `pyproject.toml` file to ensure more precise dependency management.

Dependency version constraint updates:

* Changed the `requires-python` field to use the compatible release operator (`~=3.13.0`) instead of a minimum version, ensuring the project runs only on Python 3.13.x releases.
* Updated the `required-version` for the `uv` tool to `~=0.8.0`, restricting it to compatible 0.8.x releases.