### PR TITLE
Update Pull Request Tasks Permissions

### DIFF
--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -4,8 +4,7 @@ on:
   pull_request:
     types: [opened, edited, synchronize]
 
-permissions:
-  pull-requests: read
+permissions: {}
 
 jobs:
   common-pull-request-tasks:


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes a small adjustment to the workflow permissions in `.github/workflows/pull-request-tasks.yml`, setting the `permissions` field to an empty object. This means the workflow will now use the default permissions instead of explicitly setting `pull-requests: read`.